### PR TITLE
[DAO] Team, Match, and Abstract DAO and Services

### DIFF
--- a/dash-core/pom.xml
+++ b/dash-core/pom.xml
@@ -29,6 +29,11 @@
 
         <!-- Hibernate for annotations-->
         <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>persistence-api</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>

--- a/dash-core/src/main/java/org/technojays/first/model/Event.java
+++ b/dash-core/src/main/java/org/technojays/first/model/Event.java
@@ -1,28 +1,43 @@
 package org.technojays.first.model;
 
-
+import javax.persistence.*;
 import java.time.ZonedDateTime;
 
 /**
  * @author DaPortlyJester
  * @since 1/17/2015
+ * <p/>
+ * Entity to represent a FIRST Event. Includes event information
+ * such as event start time and venue
  */
+@Entity
+@Table(name = "events", schema = "first")
 public class Event {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "id", unique = true, nullable = false)
     private Long id;
 
+    @Column(name = "name")
     private String name;
 
+    @Column(name = "type")
     private EventType type;
 
+    @Column(name = "venue")
     private String venue;
 
+    @Column(name = "location")
     private String location;
 
+    @Column(name = "start")
     private ZonedDateTime startDate;
 
+    @Column(name = "end")
     private ZonedDateTime endDate;
 
+    @Column(name = "code")
     private String eventCode;
 
     public Long getId() {

--- a/dash-core/src/main/java/org/technojays/first/model/FIRSTProgram.java
+++ b/dash-core/src/main/java/org/technojays/first/model/FIRSTProgram.java
@@ -1,0 +1,31 @@
+package org.technojays.first.model;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015.
+ *
+ * FIRST Programs enumeration. Contains information about FIRST current
+ * programs
+ */
+public enum FIRSTProgram {
+    JUNIOR_FLL("Junior FIRST Lego League", "K-3"),
+    FLL("FIRST Lego League", "4-8"),
+    FTC("FIRST Tech Challenge", "7-12"),
+    FRC("FIRST Robotics Competition", "9-12");
+
+    private String programName;
+    private String grades;
+
+    FIRSTProgram(String programName, String grades) {
+        this.programName = programName;
+        this.grades = grades;
+    }
+
+    public String getProgramName() {
+        return programName;
+    }
+
+    public String getGrades() {
+        return grades;
+    }
+}

--- a/dash-core/src/main/java/org/technojays/first/model/Game.java
+++ b/dash-core/src/main/java/org/technojays/first/model/Game.java
@@ -1,8 +1,61 @@
 package org.technojays.first.model;
 
+import javax.persistence.*;
+import java.time.Year;
+
 /**
  * @author DaPortlyJester
  * @since 1/17/2015
+ *
+ * Entity representing a FIRST "Game". A "Game" defines the basic attributes
+ * of the challenge for each year.
  */
+@Entity
+@Table(name = "games", schema = "first")
 public class Game {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "id", unique = true, nullable = false)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "year")
+    private Year year;
+
+    @Column(name = "program")
+    private FIRSTProgram program;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Year getYear() {
+        return year;
+    }
+
+    public void setYear(Year year) {
+        this.year = year;
+    }
+
+    public FIRSTProgram getProgram() {
+        return program;
+    }
+
+    public void setProgram(FIRSTProgram program) {
+        this.program = program;
+    }
 }

--- a/dash-core/src/main/java/org/technojays/first/model/Match.java
+++ b/dash-core/src/main/java/org/technojays/first/model/Match.java
@@ -7,24 +7,25 @@ import java.util.Set;
 /**
  * @author DaPortlyJester
  * @since 1/19/2015
+ *
+ * Entity representing a match at a competition or event
  */
-@Table(name = "matches")
+@Entity
+@Table(name = "matches", schema = "first")
 public class Match {
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "id", unique = true, nullable = false)
     private Long id;
 
     @Column(name = "match_number")
-    private Long matchNumber;
+    private Long matchNum;
 
     @ManyToOne(cascade = CascadeType.ALL)
-    @Column(name = "game_id")
     @JoinColumn(name = "id")
     private Game game;
 
     @ManyToOne(cascade = CascadeType.ALL)
-    @Column(name = "event_id")
     @JoinColumn(name = "id")
     private Event event;
 

--- a/dash-core/src/main/java/org/technojays/first/model/MatchScore.java
+++ b/dash-core/src/main/java/org/technojays/first/model/MatchScore.java
@@ -6,12 +6,13 @@ import javax.persistence.*;
  * @author DaPortlyJester
  * @since 1/19/2015
  */
+@Entity
 @Table(name = "match_score")
 public class MatchScore {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @Column(name = "id", unique = true, nullable = true)
+    @Column(name = "id", unique = true, nullable = false)
     private Long id;
 
     @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/dash-core/src/main/java/org/technojays/first/model/Team.java
+++ b/dash-core/src/main/java/org/technojays/first/model/Team.java
@@ -6,8 +6,12 @@ import java.util.Set;
 /**
  * @author DaPortlyJester
  * @since 1/17/2015
+ * <p/>
+ * Entity to represent team information.
  */
-@Table(name = "teams")
+
+@Entity
+@Table(name = "teams", schema = "first")
 public class Team {
 
     @Id
@@ -19,17 +23,17 @@ public class Team {
     private Long teamNum;
 
     @Column(name = "name", nullable = false)
-    private String Name;
+    private String name;
 
     @Column(name = "short_name")
     private String shortName;
 
-    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "alliances",
-            joinColumns = {@JoinColumn(name = "team_id", referencedColumnName = "id")},
-            inverseJoinColumns = {@JoinColumn(name = "match_id", referencedColumnName = "id")})
-    private Set<Match> matches;
+//    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    @JoinTable(
+//            name = "alliances",
+//            joinColumns = {@JoinColumn(name = "team_id", referencedColumnName = "id")},
+//            inverseJoinColumns = {@JoinColumn(name = "match_id", referencedColumnName = "id")})
+//    private Set<Match> matches;
 
 
     public Long getId() {
@@ -49,11 +53,11 @@ public class Team {
     }
 
     public String getName() {
-        return Name;
+        return name;
     }
 
     public void setName(String name) {
-        Name = name;
+        this.name = name;
     }
 
     public String getShortName() {
@@ -64,11 +68,11 @@ public class Team {
         this.shortName = shortName;
     }
 
-    public Set<Match> getMatches() {
-        return matches;
-    }
-
-    public void setMatches(Set<Match> matches) {
-        this.matches = matches;
-    }
+//    public Set<Match> getMatches() {
+//        return matches;
+//    }
+//
+//    public void setMatches(Set<Match> matches) {
+//        this.matches = matches;
+//    }
 }

--- a/dash-core/src/main/java/org/technojays/first/model/metamodel/Game_.java
+++ b/dash-core/src/main/java/org/technojays/first/model/metamodel/Game_.java
@@ -1,0 +1,20 @@
+package org.technojays.first.model.metamodel;
+
+import org.technojays.first.model.FIRSTProgram;
+import org.technojays.first.model.Game;
+
+import javax.persistence.metamodel.SingularAttribute;
+import java.time.Year;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015
+ *
+ * Hibernate metamodel for Game for criteria building
+ */
+public class Game_ {
+    public static volatile SingularAttribute<Game, Long> id;
+    public static volatile SingularAttribute<Game, String> name;
+    public static volatile SingularAttribute<Game, Year> year;
+    public static volatile SingularAttribute<Game, FIRSTProgram> program;
+}

--- a/dash-core/src/main/java/org/technojays/first/model/metamodel/Match_.java
+++ b/dash-core/src/main/java/org/technojays/first/model/metamodel/Match_.java
@@ -1,0 +1,24 @@
+package org.technojays.first.model.metamodel;
+
+import org.technojays.first.model.*;
+
+import javax.persistence.metamodel.SetAttribute;
+import javax.persistence.metamodel.SingularAttribute;
+import java.time.ZonedDateTime;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015
+ *
+ * Hibernate metamodel for matches for criteria building
+ */
+public class Match_ {
+    public static volatile SingularAttribute<Match, Long> id;
+    public static volatile SingularAttribute<Match, Long> matchNum;
+    public static volatile SingularAttribute<Match, Game> game;
+    public static volatile SingularAttribute<Match, Event> event;
+    public static volatile SingularAttribute<Match, ZonedDateTime> start;
+    public static volatile SingularAttribute<Match, MatchType> type;
+    public static volatile SetAttribute<Match, Team> teams;
+    public static volatile SetAttribute<Match, MatchScore> scores;
+}

--- a/dash-core/src/main/java/org/technojays/first/model/metamodel/Team_.java
+++ b/dash-core/src/main/java/org/technojays/first/model/metamodel/Team_.java
@@ -1,0 +1,20 @@
+package org.technojays.first.model.metamodel;
+
+import org.technojays.first.model.Team;
+
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015.
+ *
+ * Hibernate metamodel for teams for criteria building
+ */
+@StaticMetamodel( Team.class)
+public class Team_ {
+    public static volatile SingularAttribute<Team, Long> id;
+    public static volatile SingularAttribute<Team, Long> teamNum;
+    public static volatile SingularAttribute<Team, String> name;
+    public static volatile SingularAttribute<Team, String> shortName;
+}

--- a/dash-server/pom.xml
+++ b/dash-server/pom.xml
@@ -43,6 +43,18 @@
             <version>${hk2.version}</version>
         </dependency>
 
+        <!-- Guice persist for Hibernate Integration and Guice Servlet for servlet integration -->
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-servlet</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+
         <!--
         Because moxy gets a teabag ...
         Jackson (FasterXml) for Joda and Guice Injection JSON Support -->
@@ -74,11 +86,21 @@
             <artifactId>jersey-media-moxy</artifactId>
         </dependency> -->
 
-        <!-- Hibernate -->
+        <!-- Hibernate and Search Version-->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
             <version>${hibernate.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <version>${hibernate.search.version}</version>
         </dependency>
 
         <!-- Jetty is an optional embedded server that TODO will be used as part of the test framework *shameface* -->
@@ -103,6 +125,12 @@
             <version>${dash.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgres.version}</version>
+        </dependency>
+
         <!-- LOL WUT? -->
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
@@ -111,10 +139,24 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- Test Dependencies -->
+        <!-- Jukito Test Dependencies -->
+        <dependency>
+            <groupId>org.jukito</groupId>
+            <artifactId>jukito</artifactId>
+            <version>1.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.185</version>
+        </dependency>
+
     </dependencies>
 
     <build>
-        <finalName>first-dash</finalName>
+        <finalName>${artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dash-server/src/main/java/Main.java
+++ b/dash-server/src/main/java/Main.java
@@ -1,0 +1,54 @@
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.Session;
+import org.hibernate.Query;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.ServiceRegistryBuilder;
+
+import java.util.Map;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/1/2015.
+ */
+public class Main {
+    private static final SessionFactory ourSessionFactory;
+    private static final ServiceRegistry serviceRegistry;
+
+    static {
+        try {
+            Configuration configuration = new Configuration();
+            configuration.configure();
+
+            serviceRegistry = new ServiceRegistryBuilder().applySettings(configuration.getProperties()).buildServiceRegistry();
+            ourSessionFactory = configuration.buildSessionFactory(serviceRegistry);
+        } catch (Throwable ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    public static Session getSession() throws HibernateException {
+        return ourSessionFactory.openSession();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Session session = getSession();
+        try {
+            System.out.println("querying all the managed entities...");
+            final Map metadataMap = session.getSessionFactory().getAllClassMetadata();
+            for (Object key : metadataMap.keySet()) {
+                final ClassMetadata classMetadata = (ClassMetadata) metadataMap.get(key);
+                final String entityName = classMetadata.getEntityName();
+                final Query query = session.createQuery("from " + entityName);
+                System.out.println("executing: " + query.getQueryString());
+                for (Object o : query.list()) {
+                    System.out.println("  " + o);
+                }
+            }
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/DashAppConfig.java
+++ b/dash-server/src/main/java/org/technojays/first/DashAppConfig.java
@@ -2,6 +2,7 @@ package org.technojays.first;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.persist.PersistService;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
@@ -9,6 +10,7 @@ import org.jvnet.hk2.guice.bridge.api.GuiceIntoHK2Bridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.technojays.first.inject.ConfigurationInjection;
+import org.technojays.first.inject.DashGuiceH4Module;
 import org.technojays.first.inject.JSONInjection;
 
 import javax.inject.Inject;
@@ -35,8 +37,11 @@ public class DashAppConfig extends ResourceConfig {
         logger.info("Building Injectors");
         Injector injector = Guice.createInjector(
                 new ConfigurationInjection(),
+                new DashGuiceH4Module(),
                 new JSONInjection()
         );
+
+        PersistentInit persistenceInit = new PersistentInit();
 
         GuiceBridge.getGuiceBridge().initializeGuiceBridge(serviceLocator);
 
@@ -44,4 +49,18 @@ public class DashAppConfig extends ResourceConfig {
         guiceBridge.bridgeGuiceInjector(injector);
     }
 
+    /**
+     * Initialize Persistence Servoce
+     */
+    public class PersistentInit {
+
+        @Inject
+        PersistentInit(PersistService service) {
+            service.start();
+        }
+
+        PersistentInit(){
+
+        }
+    }
 }

--- a/dash-server/src/main/java/org/technojays/first/dao/AbstractDAO.java
+++ b/dash-server/src/main/java/org/technojays/first/dao/AbstractDAO.java
@@ -1,0 +1,116 @@
+package org.technojays.first.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.metamodel.EntityType;
+import java.util.List;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015
+ * <p/>
+ * Abstract DAO for all Entity types to implement
+ */
+public abstract class AbstractDAO<T> {
+    protected Class<T> entityClass;
+
+    @Inject
+    private EntityManager em;
+
+    public AbstractDAO(Class<T> entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    /**
+     * Get entity manager for this DAO
+     * @return Entity Manager associated with this DAO
+     */
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    /**
+     * Get the metamodel associated with the entity for this DAO
+     * @return metamodel for the entity associated with this metamodel
+     */
+    protected EntityType<T> getMetaModel() {
+        return getEntityManager().getMetamodel().entity(entityClass);
+    }
+
+    @Transactional
+    public void save(T entity) {
+        getEntityManager().getTransaction().begin();
+        getEntityManager().persist(entity);
+        getEntityManager().getTransaction().commit();
+    }
+
+    @Transactional
+    public void update(T entity) {
+        getEntityManager().getTransaction().begin();
+        getEntityManager().merge(entity);
+        getEntityManager().getTransaction().commit();
+    }
+
+    @Transactional
+    public void remove(Long entityId) {
+        T entity = find(entityId);
+
+        if (entity != null)
+            remove(entity);
+        getEntityManager().getTransaction().commit();
+    }
+
+    @Transactional
+    public void remove(T entity) {
+        getEntityManager().getTransaction().begin();
+        getEntityManager().remove(getEntityManager().merge(entity));
+        getEntityManager().getTransaction().commit();
+    }
+
+    public T find(Object id) {
+        return getEntityManager().find(entityClass, id);
+    }
+
+    public List<T> findAll() {
+        CriteriaQuery<T> cq = getEntityManager().getCriteriaBuilder()
+                .createQuery(entityClass);
+        cq.select(cq.from(entityClass));
+
+        return getResultList(cq);
+    }
+
+    public List<T> findRange(int start, int end) {
+        CriteriaQuery<T> cq = getEntityManager().getCriteriaBuilder()
+                .createQuery(entityClass);
+        cq.select(cq.from(entityClass));
+
+        javax.persistence.Query q = getEntityManager().createQuery(cq);
+        q.setMaxResults(end - start);
+        q.setFirstResult(start);
+
+        return q.getResultList();
+    }
+
+    public int count() {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<T> root = cq.from(entityClass);
+        cq.select(cb.count(root));
+        Long count = getEntityManager().createQuery(cq).getSingleResult();
+
+        return count.intValue();
+    }
+
+    public T getSingleResult(CriteriaQuery<T> cq) {
+        return getEntityManager().createQuery(cq).getSingleResult();
+    }
+
+    public List<T> getResultList(CriteriaQuery<T> cq) {
+        return getEntityManager().createQuery(cq).getResultList();
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/dao/MatchDAO.java
+++ b/dash-server/src/main/java/org/technojays/first/dao/MatchDAO.java
@@ -1,0 +1,36 @@
+package org.technojays.first.dao;
+
+import org.technojays.first.model.Match;
+import org.technojays.first.model.metamodel.Match_;
+
+import javax.persistence.criteria.Predicate;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015.
+ *
+ * Data Access Object for Match Entities
+ */
+public class MatchDAO extends AbstractDAO<Match> {
+
+
+    public MatchDAO() {
+        super(Match.class);
+    }
+
+    public Match getByMatchNumber(Long matchNum) {
+        QueryContainer<Match> qc = new QueryContainer<>(getEntityManager(), this.entityClass);
+
+        Predicate cond1 = qc.getCriteriaBuilder().equal(qc.getRoot().get(Match_.matchNum), matchNum);
+        qc.getCriteriaQuery().where(cond1);
+
+        return getSingleResult(qc.getCriteriaQuery());
+
+//        CriteriaBuilder builder = getEntityManager().getCriteriaBuilder();
+//        CriteriaQuery<Match> criteria = builder.createQuery(Match.class);
+//        Root<Match> matchRoot = criteria.from(Match.class);
+//        criteria.select(matchRoot);
+//        criteria.where(builder.equal(matchRoot.get(Match_.matchNum), matchNum));
+//        return entityManager.createQuery(criteria).getSingleResult();
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/dao/QueryContainer.java
+++ b/dash-server/src/main/java/org/technojays/first/dao/QueryContainer.java
@@ -1,0 +1,38 @@
+package org.technojays.first.dao;
+
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/10/2015.
+ *
+ * Container for highly related query objects
+ */
+public class QueryContainer<T> {
+
+    private final CriteriaBuilder criteriaBuilder;
+    private final CriteriaQuery<T> criteriaQuery;
+    private final Root<T> root;
+
+    public QueryContainer(EntityManager em, Class<T> clazz) {
+        criteriaBuilder = em.getCriteriaBuilder();
+        criteriaQuery = criteriaBuilder.createQuery(clazz);
+        root = criteriaQuery.from(clazz);
+    }
+
+    public CriteriaBuilder getCriteriaBuilder() {
+        return criteriaBuilder;
+    }
+
+    public CriteriaQuery<T> getCriteriaQuery() {
+        return criteriaQuery;
+    }
+
+    public Root<T> getRoot() {
+        return root;
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/dao/TeamDAO.java
+++ b/dash-server/src/main/java/org/technojays/first/dao/TeamDAO.java
@@ -1,0 +1,34 @@
+package org.technojays.first.dao;
+
+import org.technojays.first.model.Team;
+import org.technojays.first.model.metamodel.Team_;
+
+import javax.persistence.criteria.Predicate;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/5/2015.
+ * <p/>
+ * Data Access Object for Team Entities
+ */
+public class TeamDAO extends AbstractDAO<Team> {
+
+    public TeamDAO() {
+        super(Team.class);
+    }
+
+    /**
+     * Retrieve team by team number
+     * @param teamNum Team number to find
+     * @return Team associated with given team number
+     */
+    public Team getByTeamNumber(Long teamNum) {
+        QueryContainer<Team> qc = new QueryContainer<>(getEntityManager(), this.entityClass);
+
+        Predicate cond1 = qc.getCriteriaBuilder().equal(qc.getRoot().get(Team_.teamNum), teamNum);
+        qc.getCriteriaQuery().where(cond1);
+
+        return getSingleResult(qc.getCriteriaQuery());
+    }
+
+}

--- a/dash-server/src/main/java/org/technojays/first/inject/ConfigurationInjection.java
+++ b/dash-server/src/main/java/org/technojays/first/inject/ConfigurationInjection.java
@@ -5,6 +5,7 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.technojays.first.util.FDC;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -24,10 +25,10 @@ public class ConfigurationInjection implements Module {
     @Override
     public void configure(Binder binder) {
         Properties appProperties;
-        String configFile = System.getProperty("dash.config.file");
+        String configFile = System.getProperty(FDC.DASH_CONFIG_FILE);
 
         if (configFile != null && !configFile.isEmpty()) {
-            logger.debug("Found config file {}.", configFile);
+            logger.debug("Using config file {}.", configFile);
             appProperties = new Properties();
             try {
                 appProperties.load(new FileReader(configFile));
@@ -38,12 +39,14 @@ public class ConfigurationInjection implements Module {
         } else {
             logger.debug("Configuring using environment properties");
             appProperties = System.getProperties();
-            /**
-             * Uncomment to see loaded environment properties - All properties are loaded from environment on Heroku
-             * See system.properties file for more information
-            for(String propertyName : appProperties.stringPropertyNames()){
-                logger.debug("Property: {} - {}", propertyName, appProperties.getProperty(propertyName));
-            }**/
+        }
+
+        /**
+         * Uncomment to see loaded environment properties - All properties are loaded from environment on Heroku
+         * See system.properties file for more information
+         */
+        for(String propertyName : appProperties.stringPropertyNames()){
+            logger.debug("Property: {} - {}", propertyName, appProperties.getProperty(propertyName));
         }
 
         // binds properties for Guice

--- a/dash-server/src/main/java/org/technojays/first/inject/DashGuiceH4Module.java
+++ b/dash-server/src/main/java/org/technojays/first/inject/DashGuiceH4Module.java
@@ -1,0 +1,78 @@
+package org.technojays.first.inject;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.name.Names;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technojays.first.util.FDC;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/1/2015.
+ * <p/>
+ * Guice Configuration / Injection for Hibernate for Service
+ */
+public class DashGuiceH4Module implements Module {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    // Thread Local here for one entity
+    private static final ThreadLocal<EntityManager> ENTITY_MANAGER_CACHE
+            = new ThreadLocal<EntityManager>();
+
+    private static Properties h4Properties;
+
+    @Override
+    public void configure(Binder binder) {
+        String configFile = System.getProperty(FDC.DASH_H4_CONFIG_FILE);
+
+        if (configFile != null && !configFile.isEmpty()) {
+            logger.debug("Using H4 config file {}.", configFile);
+            h4Properties = new Properties();
+            try {
+                h4Properties.load(new FileReader(configFile));
+            } catch (IOException e) {
+                logger.error("Failed to read specified H4 properties file {}", configFile, e);
+                throw new RuntimeException("Unable to read specified H4 dash.config.file", e);
+            }
+        } else {
+            logger.debug("Configuring using environment properties");
+            h4Properties.setProperty(FDC.H4_DRIVER, System.getProperty(FDC.H4_DRIVER));
+            h4Properties.setProperty(FDC.H4_URL, System.getProperty(FDC.H4_URL));
+            h4Properties.setProperty(FDC.H4_USER, System.getProperty(FDC.H4_USER));
+            h4Properties.setProperty(FDC.H4_PASS, System.getProperty(FDC.H4_PASS));
+            h4Properties.setProperty(FDC.H4_POOL_SIZE, System.getProperty(FDC.H4_POOL_SIZE));
+            h4Properties.setProperty(FDC.H4_DIALECT, System.getProperty(FDC.H4_DIALECT));
+            h4Properties.setProperty(FDC.H4_DDL_AUTO, System.getProperty(FDC.H4_DDL_AUTO));
+        }
+        Names.bindProperties(binder, h4Properties);
+    }
+
+    @Provides
+    @Inject
+    public EntityManagerFactory entityManagerFactory() {
+        return Persistence.createEntityManagerFactory(FDC.H4_MANAGER, h4Properties);
+    }
+
+    @Provides
+    @Inject
+    public EntityManager provideEntityManager(EntityManagerFactory entityManagerFactory) {
+        EntityManager entityManager = ENTITY_MANAGER_CACHE.get();
+        if (entityManager == null) {
+            ENTITY_MANAGER_CACHE.set(entityManager = entityManagerFactory.createEntityManager());
+        }
+        return entityManager;
+    }
+
+
+}

--- a/dash-server/src/main/java/org/technojays/first/inject/DashGuiceH4ServletModule.java
+++ b/dash-server/src/main/java/org/technojays/first/inject/DashGuiceH4ServletModule.java
@@ -1,0 +1,17 @@
+package org.technojays.first.inject;
+
+import com.google.inject.persist.PersistFilter;
+import com.google.inject.persist.jpa.JpaPersistModule;
+import com.google.inject.servlet.ServletModule;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/7/2015.
+ */
+public class DashGuiceH4ServletModule extends ServletModule {
+
+    protected void configureServlets() {
+        install(new JpaPersistModule("first_dash_local"));
+        filter("/*").through(PersistFilter.class);
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/inject/JSONInjection.java
+++ b/dash-server/src/main/java/org/technojays/first/inject/JSONInjection.java
@@ -7,6 +7,7 @@ import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import org.technojays.first.DashAppConfig;
 
 import javax.inject.Singleton;
 
@@ -35,6 +36,5 @@ public class JSONInjection implements Module {
 
     @Override
     public void configure(Binder binder) {
-        //Nothing to configure, see provides methods
     }
 }

--- a/dash-server/src/main/java/org/technojays/first/rest/TeamResource.java
+++ b/dash-server/src/main/java/org/technojays/first/rest/TeamResource.java
@@ -1,10 +1,12 @@
 package org.technojays.first.rest;
 
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.technojays.first.exception.DashException;
 import org.technojays.first.model.Team;
+import org.technojays.first.service.TeamService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,36 +26,57 @@ import java.util.List;
 public class TeamResource extends DashResource{
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    private TeamService teamService;
+
+    @Inject
+    public TeamResource(TeamService teamService){
+        this.teamService = teamService;
+    }
+
+    /**
+     * Get team by FIRST Dash Id
+     *
+     * @param idParam Id of the team
+     * @return Team associated with given system id number
+     * @throws DashException
+     */
     @GET
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Team getTeam(@PathParam("id") String idParam) throws DashException {
-        logger.debug("Getting team by id");
+        logger.debug("Getting team by id {}", idParam);
         Long id = getLongFromParameter(idParam);
-        Team team = new Team();
-        team.setId(id);
+        Team team = teamService.getTeamById(id);
         return team;
     }
 
-
+    /**
+     * Get all teams
+     *
+     * @return All known teams
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<Team> getTeams() {
         logger.debug("Getting full list of teams");
-        List<Team> teams = new ArrayList<Team>();
-        teams.add(new Team());
-        teams.add(new Team());
+        List<Team> teams = teamService.getTeams();
         return teams;
     }
 
+    /**
+     * Get team by team number
+     *
+     * @param teamNumber Number associated with the team by FIRST
+     * @return Team associated with team number
+     * @throws DashException
+     */
     @GET
     @Path("/number/{number}")
     @Produces(MediaType.APPLICATION_JSON)
     public Team getTeamByTeamNumber(@PathParam("number") String teamNumber) throws DashException {
-        logger.debug("Getting team by team number");
+        logger.debug("Getting team by team number {}", teamNumber);
         Long teamNum = getLongFromParameter(teamNumber);
-        Team team = new Team()                   ;
-        team.setTeamNum(teamNum);
+        Team team = teamService.getTeamByTeamNumber(teamNum);
         return team;
     }
 }

--- a/dash-server/src/main/java/org/technojays/first/service/H4MatchService.java
+++ b/dash-server/src/main/java/org/technojays/first/service/H4MatchService.java
@@ -1,0 +1,56 @@
+package org.technojays.first.service;
+
+import com.google.inject.Inject;
+import org.technojays.first.dao.MatchDAO;
+import org.technojays.first.model.Match;
+import org.technojays.first.model.MatchType;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015
+ *
+ * Match Service for Hibernate 4
+ */
+public class H4MatchService implements MatchService {
+
+    @Inject
+    MatchDAO matchDAO;
+
+    @Override
+    public Match getMatchById(Long id) {
+        return null;
+    }
+
+    @Override
+    public Match getMatchByMatchNumber(Long matchNum) {
+        return null;
+    }
+
+    @Override
+    public List<Match> getMatchesByEventId(Long eventId) {
+        return null;
+    }
+
+    @Override
+    public List<Match> getMatchesAfterTime(ZonedDateTime start) {
+        return null;
+    }
+
+    @Override
+    public List<Match> getMatchesByTypeAndEvent(MatchType type, Long eventId) {
+        return null;
+    }
+
+    @Override
+    public List<Match> getMatchesByTeamAndEvent(Long teamId, Long eventId) {
+        return null;
+    }
+
+    @Override
+    public Match saveMatch(Match match) {
+        return null;
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/service/H4TeamService.java
+++ b/dash-server/src/main/java/org/technojays/first/service/H4TeamService.java
@@ -1,0 +1,40 @@
+package org.technojays.first.service;
+
+import com.google.inject.Inject;
+import org.technojays.first.dao.TeamDAO;
+import org.technojays.first.model.Team;
+
+import java.util.List;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/5/2015.
+ * <p/>
+ * Team Service for Hibernate 4
+ */
+public class H4TeamService implements TeamService {
+
+    @Inject
+    TeamDAO teamDAO;
+
+    @Override
+    public Team getTeamById(Long id) {
+        return teamDAO.find(id);
+    }
+
+    @Override
+    public Team getTeamByTeamNumber(Long teamNumber) {
+        return teamDAO.getByTeamNumber(teamNumber);
+    }
+
+    @Override
+    public List<Team> getTeams() {
+        return teamDAO.findAll();
+    }
+
+    @Override
+    public Team saveTeam(Team team) {
+        teamDAO.save(team);
+        return team;
+    }
+}

--- a/dash-server/src/main/java/org/technojays/first/service/MatchService.java
+++ b/dash-server/src/main/java/org/technojays/first/service/MatchService.java
@@ -1,0 +1,31 @@
+package org.technojays.first.service;
+
+import org.technojays.first.model.Match;
+import org.technojays.first.model.MatchType;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/9/2015.
+ * <p/>
+ * Service interfave to retrieve match information
+ */
+public interface MatchService {
+
+    public Match getMatchById(Long id);
+
+    public Match getMatchByMatchNumber(Long matchNum);
+
+    public List<Match> getMatchesByEventId(Long eventId);
+
+    public List<Match> getMatchesAfterTime(ZonedDateTime start);
+
+    public List<Match> getMatchesByTypeAndEvent(MatchType type, Long eventId);
+
+    public List<Match> getMatchesByTeamAndEvent(Long teamId, Long eventId);
+
+    public Match saveMatch(Match match);
+
+}

--- a/dash-server/src/main/java/org/technojays/first/service/TeamService.java
+++ b/dash-server/src/main/java/org/technojays/first/service/TeamService.java
@@ -1,7 +1,24 @@
 package org.technojays.first.service;
 
+import org.technojays.first.model.Team;
+
+import java.util.List;
+
 /**
- * Created by DaPortlyJester on 1/17/2015.
+ * Created by DaPortlyJester
+ *
+ * @since 1/17/2015.
+ * <p/>
+ * Service interface to retrieve Team information
  */
 public interface TeamService {
+
+    Team getTeamById(Long id);
+
+    Team getTeamByTeamNumber(Long teamNumber);
+
+    List<Team> getTeams();
+
+    Team saveTeam(Team team);
+
 }

--- a/dash-server/src/main/java/org/technojays/first/util/FDC.java
+++ b/dash-server/src/main/java/org/technojays/first/util/FDC.java
@@ -1,0 +1,22 @@
+package org.technojays.first.util;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/7/2015.
+ *
+ * FIRST DASH Contants File
+ */
+public class FDC {
+
+    public final static String H4_DRIVER = "hibernate.connnection.driver_class";
+    public final static String H4_URL = "hibernate.connnection.url";
+    public final static String H4_USER = "hibernate.connnection.username";
+    public final static String H4_PASS = "hibernate.connnection.password";
+    public final static String H4_POOL_SIZE = "hibernate.connnection.pool_size";
+    public final static String H4_DIALECT = "hibernate.dialect";
+    public final static String H4_DDL_AUTO = "hibernate.hbm2ddl.auto";
+
+    public final static String H4_MANAGER = "dash_manager";
+    public static final String DASH_H4_CONFIG_FILE = "dash.h4.config.file";
+    public static final String DASH_CONFIG_FILE = "dash.config.file";
+}

--- a/dash-server/src/main/java/org/technojays/first/util/PSQL.java
+++ b/dash-server/src/main/java/org/technojays/first/util/PSQL.java
@@ -1,0 +1,12 @@
+package org.technojays.first.util;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/7/2015.
+ */
+public class PSQL {
+
+    public static final String SELECT_TEAMS = "SELECT t FROM Team t";
+    public static String SELECT_TEAM_BY_ID = "SELECT t FROM Team t where t.id=:id";
+    public static String SELECT_TEAM_BY_TEAM_NUMBER = "SELECT t FROM Team t where t.teamNumber=:teamNumber";
+}

--- a/dash-server/src/main/resources/META-INF/persistence.xml
+++ b/dash-server/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="dash_manager">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>org.technojays.first.model.Team</class>
+        <!--<class>org.technojays.first.model.Match</class>-->
+        <properties>
+            <!-- Disable Second Level Cache -->
+            <property name="hibernate.cache.provider_class" value="org.hibernate.cache.internal.NoCachingRegionFactory"/>
+            <!-- Remove backwards compatability -->
+            <property name="hibernate.id.new_generator_mappings" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dash-server/src/main/webapp/META-INF/persistence.xml
+++ b/dash-server/src/main/webapp/META-INF/persistence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="dash_manager">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>org.technojays.first.model.Team</class>
+        <properties>
+            <!-- Disable Second Level Cache -->
+            <property name="hibernate.cache.provider_class" value="org.hibernate.cache.internal.NoCachingRegionFactory"/>
+            <!-- Remove backwards compatability -->
+            <property name="hibernate.id.new_generator_mappings" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/dash-server/src/test/java/org/technojays/first/inject/DashGuiceH4ModuleH2Test.java
+++ b/dash-server/src/test/java/org/technojays/first/inject/DashGuiceH4ModuleH2Test.java
@@ -1,0 +1,54 @@
+package org.technojays.first.inject;
+
+import org.jukito.JukitoRunner;
+import org.jukito.UseModules;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.technojays.first.dao.TeamDAO;
+import org.technojays.first.model.Team;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Derelle.Redmond
+ * @since 2/7/2015.
+ */
+@RunWith(JukitoRunner.class)
+public class DashGuiceH4ModuleH2Test {
+
+    @Test
+    @UseModules({ConfigurationInjection.class, DashGuiceH4Module.class})
+    public void testDB(TeamDAO teamDAO) {
+        Team team = new Team();
+        // If we set the id before persisting, the entity will be found
+        // to be detached
+        //team.setId(1L);
+        team.setName("TestName");
+        team.setTeamNum(1L);
+        team.setShortName("STN");
+        teamDAO.save(team);
+
+        Team retrievedTeam = teamDAO.find(team.getId());
+        assertEquals(team.getId(), retrievedTeam.getId());
+        assertEquals(team.getName(), retrievedTeam.getName());
+        assertEquals(team.getShortName(), retrievedTeam.getShortName());
+
+        retrievedTeam.setName("updatedName");
+        teamDAO.update(team);
+
+        Team updatedTeam = teamDAO.find(retrievedTeam.getId());
+        assertEquals(retrievedTeam.getId(), updatedTeam.getId());
+        assertEquals(retrievedTeam.getName(), updatedTeam.getName());
+        assertEquals(retrievedTeam.getShortName(), updatedTeam.getShortName());
+
+        List<Team> teams = teamDAO.findAll();
+        Iterator itr = teams.iterator();
+        Team teamFromList = (Team)itr.next();
+        assertEquals(updatedTeam.getId(), teamFromList.getId());
+        assertEquals(updatedTeam.getName(), teamFromList.getName());
+        assertEquals(updatedTeam.getShortName(), teamFromList.getShortName());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,16 @@
         <guice.version>4.0-beta5</guice.version>
         <guava.version>18.0</guava.version>
         <joda.version>2.7</joda.version>
-        <joda.hibernate.version>1.3</joda.hibernate.version>
         <hibernate.version>4.3.8.Final</hibernate.version>
+        <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
+        <hibernate.search.version>5.0.1.Final</hibernate.search.version>
         <postgres.version>9.3-1102-jdbc41</postgres.version>
 
         <jetty.version>9.0.6.v20130930</jetty.version>
     </properties>
 
     <build>
+        <finalName>${artifactId}</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Created basic service and data access object for Teams. Created simple teams
test to run on clean database. Created an Abstract DAO implementation and
refactored for Matches DAO implementation. Created Matches service to access
match information. Manually inserted transaction management in abstract dao
due to annotations not working without JpaPersist of Guice modules.

TODO: Investigate JpaPersist module implementation and how to integrate with
non-static persistence.xml properties.

QA: Confirm that teams are appropriately created and retrieved from api calls.